### PR TITLE
get_handler now uses 'match' (after query on reddit /r/rust)

### DIFF
--- a/03-GildedRose/rust/src/gildedrose/mod.rs
+++ b/03-GildedRose/rust/src/gildedrose/mod.rs
@@ -105,18 +105,6 @@ fn get_handler(name: &String) -> Box<Fn(&mut Item) -> ()>  {
                 wrap_handler(Box::new(generic_handler))
             }
     }
-/*
-    if name == AGED_BRIE {
-        wrap_handler(Box::new(aged_brie_handler))
-    } else if name == MAGIC_HAND  {
-        Box::new(no_op_handler)
-    } else if name == BACKSTAGE_PASSES  {
-        wrap_handler(Box::new(backstage_passes_handler))
-    } else if name.contains(CONJURED) {
-        wrap_handler(Box::new(conjured_handler))        
-    } else {
-        wrap_handler(Box::new(generic_handler))
-    }*/
 }
 
 impl GildedRose {

--- a/03-GildedRose/rust/src/gildedrose/mod.rs
+++ b/03-GildedRose/rust/src/gildedrose/mod.rs
@@ -1,10 +1,10 @@
 use std::string;
 use std::vec;
 
-static AGED_BRIE: &'static str = "Aged Brie";
-static MAGIC_HAND: &'static str = "Sulfuras, Hand of Ragnaros";
-static BACKSTAGE_PASSES: &'static str = "Backstage passes to a TAFKAL80ETC concert";
-static CONJURED: &'static str = "Conjured";
+const AGED_BRIE: &'static str = "Aged Brie";
+const MAGIC_HAND: &'static str = "Sulfuras, Hand of Ragnaros";
+const BACKSTAGE_PASSES: &'static str = "Backstage passes to a TAFKAL80ETC concert";
+const CONJURED: &'static str = "Conjured";
 
 const  QUALITY_UNIT: i32 = 1;
 const  MAX_QUALITY: i32 = 50;
@@ -95,6 +95,17 @@ fn wrap_handler(f: Box<Fn(&mut Item) -> i32>) ->  Box<Fn(&mut Item) -> ()> {
 
 fn get_handler(name: &String) -> Box<Fn(&mut Item) -> ()>  {
 
+    match name.as_ref() {
+        AGED_BRIE => wrap_handler(Box::new(aged_brie_handler)), 
+        MAGIC_HAND =>  Box::new(no_op_handler),
+        BACKSTAGE_PASSES => wrap_handler(Box::new(backstage_passes_handler)), 
+        _ =>  if name.contains(CONJURED) {
+                wrap_handler(Box::new(conjured_handler)) 
+            } else {  
+                wrap_handler(Box::new(generic_handler))
+            }
+    }
+/*
     if name == AGED_BRIE {
         wrap_handler(Box::new(aged_brie_handler))
     } else if name == MAGIC_HAND  {
@@ -105,7 +116,7 @@ fn get_handler(name: &String) -> Box<Fn(&mut Item) -> ()>  {
         wrap_handler(Box::new(conjured_handler))        
     } else {
         wrap_handler(Box::new(generic_handler))
-    }
+    }*/
 }
 
 impl GildedRose {


### PR DESCRIPTION
After struggling with the "match bindings cannot shadow statics" in the get_handler function, I posted a question on reddit: 

https://www.reddit.com/r/rust/comments/7cla6u/hey_rustaceans_got_an_easy_question_ask_here/dq0l43e/

Got a reply in half an hour. It´ as simple as using 'const' instead of 'static'. 

Now get_handler can use a match expression, which is the more canonical approach.

