### PR TITLE
Rust: read (convert from) Unicode Roman Numerals code points

### DIFF
--- a/04-RomanNumerals/rust/LICENSE
+++ b/04-RomanNumerals/rust/LICENSE
@@ -1,0 +1,21 @@
+The MIT License
+
+Copyright (c) 2017 by Iwan van der Kleijn. All rights reserved. 
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/04-RomanNumerals/rust/README.md
+++ b/04-RomanNumerals/rust/README.md
@@ -88,3 +88,9 @@ $ cargo doc --no-deps --open
 ```
 
 creates HTML documentation for the application. The --no-deps option tells Cargo to generate documentation only for the app itself, and not for any crates it depends on (it doesn´t in this version). The --open option tells Cargo to open the documentation in your browser afterward. Cargo saves the new documentation files in target/ doc.
+
+## license
+
+Copyright (c) 2017 by Iwan van der Kleijn. All rights reserved.
+
+This program is MIT licensed. See the file LICENSE.

--- a/04-RomanNumerals/rust/README.md
+++ b/04-RomanNumerals/rust/README.md
@@ -31,6 +31,10 @@ The rust solution is provided in the _romannumerals_ module. Main characteristic
 
 - Number range of supported Roman Numerals is [1 .. 3999].
 
+- The _number_value_ function can read latin character numerals, unicode code points equal to the ASCII char byte order, as well as the code points reserved in Unicode especially for Roman Numerals; code point 2160-216F. In both cases only upper case characters are supported.
+
+- the "_number_presentation_" function only renders latin character numerals as that is recommended by the Unicode standard itself
+
 - RomanNumberValue and RomanNumberPresentation Traits showcase how existing types can be extended with the functionality implemented by "_number_presentation_" and "_number_value_" respectively. String types gain a "_roman_number_value_" method and u32 integers an "_as_roman_number_" method.
 
 - Shown in the tests but not used in the Traits, the modules contains the function "_number_value2_", an alternative recursive, immutable implementation. This to compare with the compact but mutable iterative default function "_number_value_".

--- a/04-RomanNumerals/rust/src/lib.rs
+++ b/04-RomanNumerals/rust/src/lib.rs
@@ -1,5 +1,5 @@
 //! # Simple run-time wrapper for the romannumber module 
-//!
+//! 
 //! ## Details of the implementation of Kata: Roman Numerals
 //!
 //! The rust solution is provided in the _romannumerals_ module. Main characteristics of this implementation are:
@@ -26,6 +26,12 @@
 //! - Shown in the tests but not used in the Traits, the modules contains the function "_number_value2_", an 
 //!  alternative recursive, immutable implementation. This to compare with the compact but mutable iterative 
 //!  default function "_number_value_".
+//! 
+//! ## License
+//! 
+//! Copyright (c) 2017 by Iwan van der Kleijn. All rights reserved.
+//! 
+//! This program is MIT licensed. See the file LICENSE.
 
 /// Provides a type with the capability to generate a String representation 
 /// of the number in Roman Numerals
@@ -151,7 +157,6 @@ pub fn number_value(roman: &str) -> Option<u32> {
             None => return None
         };
     }
-    
     verify_number(converted.as_str(), result)
 }
 
@@ -159,11 +164,12 @@ pub fn number_value(roman: &str) -> Option<u32> {
 /// of a roman number is correct. 
 fn verify_number(roman: &str, val: u32) -> Option<u32>{
     match number_presentation(val){
-        Some(s) => if *s == *roman {
-            Some(val)
-        } else {
-            None
-        },
+        Some(s) => 
+            if s == roman {
+                Some(val)
+            } else {
+                None
+            },
         _ => None
     }
 }
@@ -173,7 +179,8 @@ fn verify_number(roman: &str, val: u32) -> Option<u32>{
 /// Give the integer value of a string representation of 
 /// a number in Roman Numerals - alternative recursive implemenation 
 pub fn number_value2(roman: &str) -> Option<u32> {
-    number_value_intern(roman, 0, roman)
+    let numerals = convert_unicode_numerals(roman);
+    number_value_intern(numerals.as_str(), 0, numerals.as_str())
 }
 
 fn number_value_intern(roman: &str, acc: u32, original: &str) -> Option<u32> {

--- a/04-RomanNumerals/rust/src/lib.rs
+++ b/04-RomanNumerals/rust/src/lib.rs
@@ -12,6 +12,13 @@
 //! 
 //! - Number range of supported Roman Numerals is [1 .. 3999].
 //! 
+//! - The _number_value_ function can read latin character numerals, unicode code points equal to the ASCII 
+//!  char byte order, as well as the code points reserved in Unicode especially for Roman Numerals; code point 
+//!  2160-216F. In both cases only upper case characters are supported.
+//!
+//! - the "_number_presentation_" function only renders latin character numerals as that is recommended by the 
+//!  Unicode standard itself
+//! 
 //! - RomanNumberValue and RomanNumberPresentation Traits showcase how existing types can be extended with the 
 //!  functionality implemented by "_number_presentation_" and "_number_value_" respectively. String types gain a 
 //!  "_roman_number_value_" method and u32 integers an "_as_roman_number_" method.
@@ -53,6 +60,11 @@ struct RomanNumeral {
     value: u32
 }
 
+struct RomanNumeralMap {
+    unicode: char,
+    ascii: &'static str
+}
+
 /// Lookup buffer to search for (scan forward) Roman Numerals with their
 /// corresponding value. Note that the order in the buffer must accoint for 
 /// search order: i.e. 'CM' must be before 'C' in order to parse the correct
@@ -72,6 +84,39 @@ const NUMERALS: [RomanNumeral; 13] = [
     RomanNumeral {symbol: "V",  value: 5},
     RomanNumeral {symbol: "IV", value: 4},
     RomanNumeral {symbol: "I",  value: 1}];
+
+
+const NUMERALS_MAPS : [RomanNumeralMap; 16] = [
+    RomanNumeralMap {unicode: 'Ⅿ',  ascii: "M"},
+    RomanNumeralMap {unicode: 'Ⅾ',  ascii: "D"},
+    RomanNumeralMap {unicode: 'Ⅽ',  ascii: "C"},
+    RomanNumeralMap {unicode: 'Ⅼ',  ascii: "L"},
+    RomanNumeralMap {unicode: 'Ⅰ',  ascii: "I"},
+    RomanNumeralMap {unicode: 'Ⅱ',  ascii: "II"},
+    RomanNumeralMap {unicode: 'Ⅲ',  ascii: "III"},
+    RomanNumeralMap {unicode: 'Ⅳ',  ascii: "IV"},
+    RomanNumeralMap {unicode: 'Ⅴ',  ascii: "V"},
+    RomanNumeralMap {unicode: 'Ⅵ',  ascii: "VI"},
+    RomanNumeralMap {unicode: 'Ⅶ',  ascii: "VII"},
+    RomanNumeralMap {unicode: 'Ⅷ',  ascii: "VIII"},
+    RomanNumeralMap {unicode: 'Ⅸ',  ascii: "IX"},
+    RomanNumeralMap {unicode: 'Ⅹ',  ascii: "X"},
+    RomanNumeralMap {unicode: 'Ⅺ',  ascii: "XI"},
+    RomanNumeralMap {unicode: 'Ⅻ',  ascii: "XII"}];
+
+fn convert_unicode_numerals(roman: &str) -> String{
+
+    let mut converted = String::new();
+
+    for c in roman.chars() 
+    {
+        match NUMERALS_MAPS.iter().find( | &l | l.unicode == c ){
+            Some(uni) => converted.push_str(uni.ascii),
+            None => converted.push(c)
+        }
+    }
+    converted
+}
 
 /// Convert a number from [1..3999] to its string representation
 /// in Roman Numerals
@@ -94,8 +139,9 @@ pub fn number_presentation(mut number: u32) -> Option<String> {
 pub fn number_value(roman: &str) -> Option<u32> {
     
     let mut result = 0;
-    let mut data = roman;
-    
+    let converted = convert_unicode_numerals(roman); 
+    let mut data = converted.as_str();
+
     while data.len() > 0  {
         result += match NUMERALS.iter().find(|num| data.starts_with(num.symbol)) {
             Some(num) => {
@@ -106,7 +152,7 @@ pub fn number_value(roman: &str) -> Option<u32> {
         };
     }
     
-    verify_number(roman, result)
+    verify_number(converted.as_str(), result)
 }
 
 /// verify if the reported integer value

--- a/04-RomanNumerals/rust/src/test.rs
+++ b/04-RomanNumerals/rust/src/test.rs
@@ -56,13 +56,24 @@ pub fn test_to_value_from_unicode(){
     //conventional max value to be able to  express in Roman Numerals
     //using the strict rules
     assert_eq!(number_value("ⅯⅯⅯⅭⅯⅩⅭⅨ").unwrap(),3999);
+
 }
+
+#[test]
+pub fn test_to_value_unicode_conversion(){
+
+    assert_eq!(number_value("ⅯⅨ").unwrap(), number_value("MIX").unwrap());
+}
+
 
 #[test]
 pub fn test_to_value_recursive_vs_iterative(){
     
     assert_eq!(number_value("X").unwrap(), number_value2("X").unwrap());
     assert_eq!(number_value("MMXVIII").unwrap(), number_value2("MMXVIII").unwrap());
+
+    //test unicode
+    assert_eq!(number_value("ⅯⅯⅯⅭⅯⅩⅭⅨ").unwrap(), number_value2("ⅯⅯⅯⅭⅯⅩⅭⅨ").unwrap());
 }
 
 #[test]
@@ -83,6 +94,9 @@ pub fn test_illegal_values(){
 
     //The composition rules for Roman Numerals are strict are can easily
     // be written wrong 
+    
+    // MDLXII = 1562, swapping D & L leads to invalid result
+    assert_eq!(number_value("MLDXII"), None); 
     assert_eq!(number_value("XXXXIX"), None);
     assert_eq!(number_value("IIIIIL"), None);
 }

--- a/04-RomanNumerals/rust/src/test.rs
+++ b/04-RomanNumerals/rust/src/test.rs
@@ -39,6 +39,26 @@ pub fn test_to_value_from_latin(){
 }
 
 #[test]
+pub fn test_to_value_from_unicode(){
+    assert_eq!(number_value("Ⅰ").unwrap(), 1);
+    assert_eq!(number_value("Ⅱ").unwrap(), 2);
+
+    assert_eq!(number_value("Ⅳ").unwrap(), 4);
+    assert_eq!(number_value("Ⅴ").unwrap(), 5);
+    assert_eq!(number_value("Ⅵ").unwrap(), 6);
+    
+    assert_eq!(number_value("Ⅽ").unwrap(), 100);
+    assert_eq!(number_value("ⅭⅯ").unwrap(), 900);
+    
+    assert_eq!(number_value("ⅯⅭⅯⅩⅭ").unwrap(), 1990);
+    assert_eq!(number_value("ⅯⅯⅩⅧ").unwrap(), 2018);
+
+    //conventional max value to be able to  express in Roman Numerals
+    //using the strict rules
+    assert_eq!(number_value("ⅯⅯⅯⅭⅯⅩⅭⅨ").unwrap(),3999);
+}
+
+#[test]
 pub fn test_to_value_recursive_vs_iterative(){
     
     assert_eq!(number_value("X").unwrap(), number_value2("X").unwrap());


### PR DESCRIPTION
Added capability to parse/read Unicode Roman Numerals like 'Ⅷ' (check it: it´s one char). Not necessarily very useful but a good excuse to play around with Unicode, chars, str and Strings in Rust. 

The Unicode standard itself recommends against *writing* Unicode Roman Numerals and argues for ISO 8859-1(Latin)/ASCII characters instead (so: "VIII" - 4 chars). So that was a good excuse to skip that part :-) 